### PR TITLE
fix: Signup redirect only after success dialog confirm

### DIFF
--- a/app/src/main/java/com/example/nexum_cliente/ui/components/SignUpSuccessDialog.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/SignUpSuccessDialog.kt
@@ -1,0 +1,58 @@
+package com.example.nexum_cliente.ui.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+
+@Composable
+fun SignUpSuccessDialog(
+    show: Boolean,
+    username: String,
+    onAccept: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (show) {
+        AlertDialog(
+            containerColor = Color.White,
+            title = {
+                Text(
+                    text = "Registro exitoso",
+                    textAlign = TextAlign.Center,
+                    fontWeight = FontWeight.Bold,
+                    modifier = modifier.fillMaxWidth()
+                )
+            },
+            text = {
+                Text(
+                    text = "El nombre de usuario autogenerado es: $username",
+                    textAlign = TextAlign.Center
+                )
+            },
+            onDismissRequest = { },
+            confirmButton = {
+                TextButton(onClick = onAccept) {
+                    Text(
+                        text = "Aceptar",
+                        color = Color.Black
+                    )
+                }
+            },
+            dismissButton = null,
+            modifier = modifier.width(500.dp),
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/sign_up/SignUpState.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/sign_up/SignUpState.kt
@@ -68,6 +68,7 @@ data class SignUpState(
     val frontDocumentUriError: Boolean = false,
     val backDocumentUriError: Boolean = false,
 
+    val isSigningUp: Boolean = false,
     val isSignedUp: Boolean = false,
     val signUpResponse: String = "",
 

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/sign_up/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/sign_up/SignUpViewModel.kt
@@ -299,18 +299,18 @@ class SignUpViewModel @Inject constructor(
                         if (exception is StorageException && exception.errorCode == StorageException.ERROR_OBJECT_NOT_FOUND) {
                             Log.w(
                                 TAG,
-                                "Image to delete was not found in Firebase 🤔. Deleting locally ♻️",
+                                "Image to delete was not found in Firebase. Deleting locally",
                                 exception
                             )
                             onDelete()
                         } else {
-                            Log.e(TAG, "❌ Error deleting image", exception)
+                            Log.e(TAG, "Error deleting image", exception)
                         }
                     }
             } else {
                 mediaManagementUseCase.uploadAndSaveImage(newUri, currentUrl, storageKey)
                     .onSuccess(onSuccess)
-                    .onFailure { Log.e(TAG, "Error uploading image ⏫", it) }
+                    .onFailure { Log.e(TAG, "Error uploading image", it) }
             }
         }
     }
@@ -390,40 +390,63 @@ class SignUpViewModel @Inject constructor(
     private fun signUp() {
         signUpJob?.cancel()
         signUpJob = viewModelScope.launch {
-            val tokenResult = getFcmTokenUseCase()
-            val tkn = tokenResult.getOrElse {
-                state = state.copy(
-                    signUpError = true,
-                    errorMessage = "No se pudo obtener el token de notificación."
-                )
-                return@launch
-            }
+            try {
+                state = state.copy(isSigningUp = true, signUpError = false, errorMessage = "")
 
-            val username = signUpMapper.generateUsername(state.name, state.lastName)
-            state = state.copy(username = username)
+                val tokenResult = getFcmTokenUseCase()
+                val tkn = tokenResult.getOrElse {
+                    state = state.copy(
+                        isSigningUp = false,
+                        signUpError = true,
+                        errorMessage = "No se pudo obtener el token de notificación."
+                    )
+                    return@launch
+                }
 
-            val signUpReq = signUpMapper.mapStateToRequest(state, tkn, username)
+                val username = signUpMapper.generateUsername(state.name, state.lastName)
+                state = state.copy(username = username)
 
-            Log.d(TAG, "SignUpRequest: ${signUpReq}")
+                val signUpReq = signUpMapper.mapStateToRequest(state, tkn, username)
 
-            authUseCases.signUp(signUpReq).collect { response ->
-                when (response) {
-                    is ApiResponse.Success -> {
-                        state =
-                            state.copy(isSignedUp = true, signUpResponse = response.data.message)
-                    }
+                Log.d(TAG, "SignUpRequest: ${signUpReq}")
 
-                    is ApiResponse.Error -> {
-                        state = state.copy(signUpError = true, errorMessage = response.errorMessage)
-                    }
+                authUseCases.signUp(signUpReq).collect { response ->
+                    when (response) {
+                        is ApiResponse.Success -> {
+                            state = state.copy(
+                                isSigningUp = false,
+                                isSignedUp = true,
+                                signUpResponse = response.data.message
+                            )
+                        }
 
-                    is ApiResponse.Failure -> {
-                        state = state.copy(signUpError = true, errorMessage = response.errorMessage)
-                    }
+                        is ApiResponse.Error -> {
+                            state = state.copy(
+                                isSigningUp = false,
+                                signUpError = true,
+                                errorMessage = response.errorMessage
+                            )
+                        }
 
-                    is ApiResponse.Loading -> { /* Opcional: mostrar un spinner global */
+                        is ApiResponse.Failure -> {
+                            state = state.copy(
+                                isSigningUp = false,
+                                signUpError = true,
+                                errorMessage = response.errorMessage
+                            )
+                        }
+
+                        is ApiResponse.Loading -> { /* Opcional: mostrar un spinner global */
+                        }
                     }
                 }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error durante signUp", e)
+                state = state.copy(
+                    isSigningUp = false,
+                    signUpError = true,
+                    errorMessage = "Ocurrió un error inesperado: ${e.message}"
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/sign_up/screens/SignUpProfilePictureScreen.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/sign_up/screens/SignUpProfilePictureScreen.kt
@@ -2,7 +2,7 @@ package com.example.nexum_cliente.ui.presenter.sign_up.screens
 
 import android.net.Uri
 import android.os.Build
-import android.util.Log
+
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -34,12 +34,14 @@ import androidx.compose.material.icons.filled.Phone
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.outlined.AddAPhoto
 import androidx.compose.material3.ButtonDefaults
+
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,7 +61,7 @@ import com.example.nexum_cliente.R
 import com.example.nexum_cliente.common.capitalizeFirstLetter
 import com.example.nexum_cliente.ui.components.ButtonComponent
 import com.example.nexum_cliente.ui.components.ImagePreview
-import com.example.nexum_cliente.ui.components.MyDialog2
+import com.example.nexum_cliente.ui.components.SignUpSuccessDialog
 import com.example.nexum_cliente.ui.navigation.rutes.AuthRoutes
 import com.example.nexum_cliente.ui.presenter.sign_up.SignUpEvent
 import com.example.nexum_cliente.ui.presenter.sign_up.SignUpState
@@ -83,6 +85,8 @@ fun SignUpProfilePictureScreen(
     val state = viewModel.state
     val context = LocalContext.current
 
+    val capturedUsername = remember(state.username) { state.username }
+
     LaunchedEffect(state.signUpError) {
         if (state.signUpError) {
             Toast.makeText(context, state.errorMessage, Toast.LENGTH_LONG).show()
@@ -92,6 +96,7 @@ fun SignUpProfilePictureScreen(
 
     SignUpProfilePictureScreenContent(
         state = state,
+        username = capturedUsername,
         onProfilePictureChanged = {
             viewModel.onEvent(SignUpEvent.ProfilePictureUriChanged(it))
         },
@@ -101,12 +106,9 @@ fun SignUpProfilePictureScreen(
         onRegister = {
             viewModel.onEvent(SignUpEvent.RegisterButtonClicked)
         },
-        onDismissSuccess = {
+        onAcceptAndNavigate = {
             viewModel.onEvent(SignUpEvent.DismissSignUpSuccessDialog)
-        },
-        onNavigateSuccess = {
-            viewModel.onEvent(SignUpEvent.DismissSignUpSuccessDialog)
-            navController.navigate(AuthRoutes.SignInScreen(username = state.username)) {
+            navController.navigate(AuthRoutes.SignInScreen(username = capturedUsername)) {
                 popUpTo(AuthRoutes.SignUpScreen) {
                     inclusive = true
                 }
@@ -120,11 +122,11 @@ fun SignUpProfilePictureScreen(
 @Preview(showBackground = true, showSystemUi = true)
 private fun SignUpProfilePictureScreenContent(
     state: SignUpState = SignUpState(),
+    username: String = "",
     onProfilePictureChanged: (Uri) -> Unit = {},
     onRemoveProfilePicture: (Int) -> Unit = {},
     onRegister: () -> Unit = {},
-    onDismissSuccess: () -> Unit = {},
-    onNavigateSuccess: () -> Unit = {}
+    onAcceptAndNavigate: () -> Unit = {}
 ) {
     val insets = WindowInsets.navigationBars.asPaddingValues()
     Nexum_clienteTheme() {
@@ -258,26 +260,23 @@ private fun SignUpProfilePictureScreenContent(
             Spacer(modifier = Modifier.height(10.dp))
             ButtonComponent(
                 value = "Terminar registro",
+                isLoading = state.isSigningUp,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = MaterialTheme.colorScheme.primary,
                     disabledContainerColor = MaterialTheme.colorScheme.surface,
                     contentColor = Color.White,
                     disabledContentColor = MaterialTheme.colorScheme.secondary
                 ),
-                isEnabled = state.isProfilePictureValid
+                isEnabled = state.isProfilePictureValid && !state.isSigningUp
             ) {
-                Log.d("SignUpButton", "Button clicked")
                 onRegister()
             }
 
-            MyDialog2(
-                title = "Registro exitoso",
+            SignUpSuccessDialog(
                 show = state.isSignedUp,
-                onDismiss = onDismissSuccess,
-                onConfirm = onNavigateSuccess
-            ) {
-                Text(text = "El nombre de usuario autogenerado es: ${state.username}")
-            }
+                username = username,
+                onAccept = onAcceptAndNavigate
+            )
         }
     }
 }


### PR DESCRIPTION
Al registrarse en dispositivos lentos o cuando el servidor responde lentamente:
- Se crea el usuario correctamente en el backend
- No se muestra el modal de éxito
- No hay redirección a la pantalla de inicio de sesión
- El usuario queda atascado en la última pantalla del signup

## Causa

No pude recrear el bug, sin embargo adjudico el origen del bug a una o varias de estas causas:

1. **Timing de navegación**: La navegación ocurría antes de que el servidor respondiera
2. **No había indicador de loading**: El usuario no sabía que el proceso estaba en curso
3. **Diálogo vulnerable**: El modal anterior podía cerrarse sin confirmar, dejando al usuario sin saber el resultado

## Solución Implementada

### 1. Nuevo Componente: `SignUpSuccessDialog`

```kotlin
// ui/components/SignUpSuccessDialog.kt

@Composable
fun SignUpSuccessDialog(
    show: Boolean,
    username: String,
    onAccept: () -> Unit,
    modifier: Modifier = Modifier
)
```

**Características:**
- Un solo botón "Aceptar" (sin botón de rechazar)
- `dismissOnBackPress = false` - No se puede cerrar con botón back
- `dismissOnClickOutside = false` - No se puede cerrar tocando fuera
- Fuerza al usuario a confirmar para continuar

### 2. Estado de Loading: `isSigningUp`

```kotlin
// SignUpState.kt
val isSigningUp: Boolean = false,
```

### 3. Captura de Username con `remember`

```kotlin
// SignUpProfilePictureScreen.kt
val capturedUsername = remember(state.username) { state.username }
```

(Esto se hace para garantiza que el username esté disponible al momento de navegar, sin depender de cambios raros en el estado).

### 4. Flujo Controlado

```
Usuario hace click en "Terminar registro"
    ↓
[Botón muestra spinner - isSigningUp = true]
    ↓
ViewModel envía solicitud al servidor
    ↓
┌─────────────────────────────────────┐
│   Server responde:                  │
├─────────────────────────────────────┤
│   Éxito → isSignedUp = true      │
│   Error → signUpError = true     │
│   Fallo → signUpError = true    │
└─────────────────────────────────────┘
    ↓
Si éxito → Muestra diálogo obligatorio
Si error → Muestra Toast con mensaje
    ↓
Usuario hace click en "Aceptar"
    ↓
Navega a SignInScreen con username
```

## Manejo de Errores

| Escenario | Comportamiento |
|-----------|----------------|
| Server lento | Usuario ve spinner, botón deshabilitado |
| Server no responde | Timeout → Toast con error |
| Error 4xx/5xx | Muestra mensaje del backend |
| Excepción inesperada | Catch general con mensaje genérico |