### PR TITLE
UI para tarjetas de credito

### DIFF
--- a/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CardTypeDetector.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CardTypeDetector.kt
@@ -1,0 +1,17 @@
+package com.example.nexum_cliente.ui.components.creditcard
+
+/**
+ * Detects the card network type from a raw card number string.
+ * Safe to call with empty or partial input.
+ */
+fun detectCardType(number: String): CardType {
+    if (number.isEmpty()) return CardType.UNKNOWN
+
+    return when {
+        number.startsWith("4") -> CardType.VISA
+        number.length >= 2 && number.substring(0, 2).toIntOrNull()
+            ?.let { it in 51..55 } == true -> CardType.MASTERCARD
+        number.startsWith("34") || number.startsWith("37") -> CardType.AMEX
+        else -> CardType.UNKNOWN
+    }
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardForm.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardForm.kt
@@ -44,7 +44,7 @@ private fun isFormValid(state: CreditCardState): Boolean =
 // Card type label
 // ---------------------------------------------------------------------------
 
-private fun CardType.label(): String = when (this) {
+internal fun CardType.label(): String = when (this) {
     CardType.VISA -> "Visa"
     CardType.MASTERCARD -> "Mastercard"
     CardType.AMEX -> "Amex"

--- a/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardForm.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardForm.kt
@@ -1,0 +1,257 @@
+package com.example.nexum_cliente.ui.components.creditcard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+private fun isCardNumberValid(raw: String): Boolean = raw.length == 16
+private fun isCardHolderNameValid(name: String): Boolean = name.isNotBlank()
+private fun isExpirationDateValid(raw: String): Boolean = raw.length == 4
+private fun isCvvValid(raw: String): Boolean = raw.length in 3..4
+
+private fun isFormValid(state: CreditCardState): Boolean =
+    isCardNumberValid(state.cardNumber) &&
+        isCardHolderNameValid(state.cardHolderName) &&
+        isExpirationDateValid(state.expirationDate) &&
+        isCvvValid(state.cvv)
+
+// ---------------------------------------------------------------------------
+// Card type label
+// ---------------------------------------------------------------------------
+
+private fun CardType.label(): String = when (this) {
+    CardType.VISA -> "Visa"
+    CardType.MASTERCARD -> "Mastercard"
+    CardType.AMEX -> "Amex"
+    CardType.UNKNOWN -> ""
+}
+
+// ---------------------------------------------------------------------------
+// Main composable
+// ---------------------------------------------------------------------------
+
+/**
+ * A reusable, self-contained credit card form built with Material 3.
+ *
+ * @param state         Current form state (hoisted).
+ * @param onStateChange Called whenever any field value changes.
+ * @param modifier      Optional [Modifier] applied to the root [Column].
+ * @param onSubmit      Called with the current [CreditCardState] when the
+ *                      submit button is tapped and all fields are valid.
+ */
+@Composable
+fun CreditCardForm(
+    state: CreditCardState,
+    onStateChange: (CreditCardState) -> Unit,
+    modifier: Modifier = Modifier,
+    onSubmit: (CreditCardState) -> Unit = {}
+) {
+    // Track which fields have been touched so we only show errors after interaction
+    var cardNumberDirty by rememberSaveable { mutableStateOf(false) }
+    var cardHolderNameDirty by rememberSaveable { mutableStateOf(false) }
+    var expirationDateDirty by rememberSaveable { mutableStateOf(false) }
+    var cvvDirty by rememberSaveable { mutableStateOf(false) }
+
+    val labelCardNumber = "Card Number"
+    val labelCardHolder = "Cardholder Name"
+    val labelExpirationDate = "Expiry (MM/YY)"
+    val labelCvv = "CVV"
+    val labelSubmit = "Submit"
+    val errorCardNumber = "Enter a valid 16-digit card number"
+    val errorCardHolder = "Cardholder name is required"
+    val errorExpirationDate = "Enter a valid expiry date (MM/YY)"
+    val errorCvv = "Enter a valid CVV (3–4 digits)"
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        // ── Card Number ──────────────────────────────────────────────────────
+        val cardNumberError = cardNumberDirty && !isCardNumberValid(state.cardNumber)
+        OutlinedTextField(
+            value = state.cardNumber,
+            onValueChange = { input ->
+                val digits = input.filter { it.isDigit() }.take(16)
+                cardNumberDirty = true
+                onStateChange(
+                    state.copy(
+                        cardNumber = digits,
+                        cardType = detectCardType(digits)
+                    )
+                )
+            },
+            label = { Text(labelCardNumber) },
+            trailingIcon = {
+                val typeLabel = state.cardType.label()
+                if (typeLabel.isNotEmpty()) {
+                    Text(
+                        text = typeLabel,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(end = 12.dp)
+                    )
+                }
+            },
+            isError = cardNumberError,
+            supportingText = {
+                if (cardNumberError) {
+                    Text(
+                        text = errorCardNumber,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            visualTransformation = CardNumberVisualTransformation(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next
+            ),
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // ── Cardholder Name ──────────────────────────────────────────────────
+        val cardHolderError = cardHolderNameDirty && !isCardHolderNameValid(state.cardHolderName)
+        OutlinedTextField(
+            value = state.cardHolderName,
+            onValueChange = { input ->
+                cardHolderNameDirty = true
+                onStateChange(state.copy(cardHolderName = input.take(26)))
+            },
+            label = { Text(labelCardHolder) },
+            isError = cardHolderError,
+            supportingText = {
+                if (cardHolderError) {
+                    Text(
+                        text = errorCardHolder,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text,
+                capitalization = KeyboardCapitalization.Words,
+                imeAction = ImeAction.Next
+            ),
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // ── Expiry + CVV side by side ────────────────────────────────────────
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            // Expiration date
+            val expiryError = expirationDateDirty && !isExpirationDateValid(state.expirationDate)
+            OutlinedTextField(
+                value = state.expirationDate,
+                onValueChange = { input ->
+                    val digits = input.filter { it.isDigit() }.take(4)
+                    expirationDateDirty = true
+                    onStateChange(state.copy(expirationDate = digits))
+                },
+                label = { Text(labelExpirationDate) },
+                isError = expiryError,
+                supportingText = {
+                    if (expiryError) {
+                        Text(
+                            text = errorExpirationDate,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                },
+                visualTransformation = ExpirationDateVisualTransformation(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next
+                ),
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+
+            // CVV
+            val cvvError = cvvDirty && !isCvvValid(state.cvv)
+            OutlinedTextField(
+                value = state.cvv,
+                onValueChange = { input ->
+                    val digits = input.filter { it.isDigit() }.take(4)
+                    cvvDirty = true
+                    onStateChange(state.copy(cvv = digits))
+                },
+                label = { Text(labelCvv) },
+                isError = cvvError,
+                supportingText = {
+                    if (cvvError) {
+                        Text(
+                            text = errorCvv,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                },
+                visualTransformation = CvvVisualTransformation(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
+                ),
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // ── Submit button ────────────────────────────────────────────────────
+        Button(
+            onClick = { onSubmit(state) },
+            enabled = isFormValid(state),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(labelSubmit)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Preview
+// ---------------------------------------------------------------------------
+
+@Preview(showBackground = true)
+@Composable
+fun CreditCardFormPreview() {
+    var state by remember { mutableStateOf(CreditCardState()) }
+    MaterialTheme {
+        CreditCardForm(
+            state = state,
+            onStateChange = { state = it },
+            onSubmit = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardState.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardState.kt
@@ -1,0 +1,16 @@
+package com.example.nexum_cliente.ui.components.creditcard
+
+data class CreditCardState(
+    val cardNumber: String = "",
+    val cardHolderName: String = "",
+    val expirationDate: String = "",
+    val cvv: String = "",
+    val cardType: CardType = CardType.UNKNOWN
+)
+
+enum class CardType {
+    VISA,
+    MASTERCARD,
+    AMEX,
+    UNKNOWN
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardTransformations.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardTransformations.kt
@@ -1,0 +1,88 @@
+package com.example.nexum_cliente.ui.components.creditcard
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+/**
+ * Formats up to 16 raw digits as XXXX XXXX XXXX XXXX.
+ * Spaces are inserted after every 4th digit.
+ */
+class CardNumberVisualTransformation : VisualTransformation {
+
+    override fun filter(text: AnnotatedString): TransformedText {
+        val raw = text.text
+        val formatted = buildString {
+            raw.forEachIndexed { index, char ->
+                if (index > 0 && index % 4 == 0) append(' ')
+                append(char)
+            }
+        }
+
+        val offsetMapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                // Number of spaces inserted before this offset
+                val spaces = when {
+                    offset <= 4 -> 0
+                    offset <= 8 -> 1
+                    offset <= 12 -> 2
+                    else -> 3
+                }
+                return (offset + spaces).coerceAtMost(formatted.length)
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                // Remove space characters that precede this transformed offset
+                val charsUpToOffset = formatted.take(offset)
+                return charsUpToOffset.count { it != ' ' }.coerceAtMost(raw.length)
+            }
+        }
+
+        return TransformedText(AnnotatedString(formatted), offsetMapping)
+    }
+}
+
+/**
+ * Formats up to 4 raw digits as MM/YY.
+ * The slash is inserted automatically after the 2nd digit.
+ */
+class ExpirationDateVisualTransformation : VisualTransformation {
+
+    override fun filter(text: AnnotatedString): TransformedText {
+        val raw = text.text
+        val formatted = buildString {
+            raw.forEachIndexed { index, char ->
+                if (index == 2) append('/')
+                append(char)
+            }
+        }
+
+        val offsetMapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                return if (offset <= 2) offset else (offset + 1).coerceAtMost(formatted.length)
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                return when {
+                    offset <= 2 -> offset
+                    offset == 3 -> 2 // cursor is on the slash — snap to before it
+                    else -> (offset - 1).coerceAtMost(raw.length)
+                }
+            }
+        }
+
+        return TransformedText(AnnotatedString(formatted), offsetMapping)
+    }
+}
+
+/**
+ * Masks all CVV characters with a bullet (•).
+ */
+class CvvVisualTransformation : VisualTransformation {
+
+    override fun filter(text: AnnotatedString): TransformedText {
+        val masked = AnnotatedString("•".repeat(text.length))
+        return TransformedText(masked, OffsetMapping.Identity)
+    }
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardVisual.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardVisual.kt
@@ -1,0 +1,157 @@
+package com.example.nexum_cliente.ui.components.creditcard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+private val CardColorVisa = listOf(Color(0xFF1A1F71), Color(0xFF2A3F99))
+private val CardColorMastercard = listOf(Color(0xFF231F20), Color(0xFFEB001B), Color(0xFFF79E1B))
+private val CardColorAmex = listOf(Color(0xFF016FD0), Color(0xFF2E9FFF))
+private val CardColorUnknown = listOf(Color(0xFF2D2D2D), Color(0xFF5A5A5A))
+
+private fun cardColors(cardType: CardType): List<Color> = when (cardType) {
+    CardType.VISA -> CardColorVisa
+    CardType.MASTERCARD -> CardColorMastercard
+    CardType.AMEX -> CardColorAmex
+    CardType.UNKNOWN -> CardColorUnknown
+}
+
+private fun chipColor(cardType: CardType): Color = when (cardType) {
+    CardType.MASTERCARD -> Color(0xFFD4AF37)
+    else -> Color(0xFFD4AF37)
+}
+
+@Composable
+fun CreditCardVisual(
+    state: CreditCardState,
+    modifier: Modifier = Modifier
+) {
+    val placeholderChar = '·'
+    val cardNumberDisplay = buildCardNumberDisplay(
+        raw = state.cardNumber,
+        placeholder = placeholderChar
+    )
+    val nameDisplay = state.cardHolderName.ifEmpty { "NOMBRE DEL TITULAR" }
+    val expiryDisplay = buildExpiryDisplay(state.expirationDate)
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    brush = Brush.horizontalGradient(cardColors(state.cardType)),
+                    shape = RoundedCornerShape(16.dp)
+                )
+                .padding(20.dp)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                // Top row: network label + card type name
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = state.cardType.label().ifEmpty { "CREDIT CARD" },
+                        style = MaterialTheme.typography.labelLarge,
+                        color = Color.White.copy(alpha = 0.9f),
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // Chip
+                Box(
+                    modifier = Modifier
+                        .size(36.dp, 26.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(chipColor(state.cardType).copy(alpha = 0.8f))
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Card number
+                Text(
+                    text = cardNumberDisplay,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = Color.White,
+                    letterSpacing = 2.sp,
+                    fontWeight = FontWeight.Medium
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Bottom row: name + expiry
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Bottom
+                ) {
+                    Text(
+                        text = nameDisplay,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.85f),
+                        fontWeight = FontWeight.Normal,
+                        letterSpacing = 1.sp,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    Text(
+                        text = expiryDisplay,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.White.copy(alpha = 0.85f),
+                        fontWeight = FontWeight.Normal,
+                        letterSpacing = 1.sp,
+                        textAlign = TextAlign.End
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun buildCardNumberDisplay(raw: String, placeholder: Char): String {
+    val padded = raw.padEnd(16, placeholder)
+    return padded.chunked(4).joinToString(" ")
+}
+
+private fun buildExpiryDisplay(raw: String): String {
+    if (raw.isEmpty()) return "MM/AA"
+    val padded = raw.padEnd(4, '·')
+    val m = padded.take(2)
+    val y = padded.drop(2).take(2)
+    return "$m/$y"
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/navigation/graphs/HomeNavGraph.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/navigation/graphs/HomeNavGraph.kt
@@ -10,12 +10,15 @@ import androidx.navigation.toRoute
 import com.example.nexum_cliente.ui.navigation.rutes.DrawerRoutes
 import com.example.nexum_cliente.ui.navigation.rutes.HomeRoutes
 import com.example.nexum_cliente.ui.navigation.rutes.JobOfferRoutes
+import com.example.nexum_cliente.ui.navigation.rutes.PlaygroundRoutes
 import com.example.nexum_cliente.ui.presenter.categories.CategoriesScreen
 import com.example.nexum_cliente.ui.presenter.chat.ChatScreen
 import com.example.nexum_cliente.ui.presenter.conversations.ConversationsScreen
 import com.example.nexum_cliente.ui.presenter.home.HomeViewModel
 import com.example.nexum_cliente.ui.presenter.job_offer.JobOfferScreen
 import com.example.nexum_cliente.ui.presenter.mercado_pago_checkout.MercadoPagoCheckout
+import com.example.nexum_cliente.ui.presenter.playground.CreditCardFormPreview
+import com.example.nexum_cliente.ui.presenter.playground.PlaygroundScreen
 import com.example.nexum_cliente.ui.presenter.profile.ProfileScreen
 import com.example.nexum_cliente.ui.presenter.requests.RequestsScreen
 import com.example.nexum_cliente.ui.presenter.settings.SettingsScreen
@@ -65,6 +68,18 @@ fun NavGraphBuilder.homeGraph(
 
         composable<DrawerRoutes.SettingsScreen> {
             SettingsScreen()
+        }
+
+        composable<DrawerRoutes.PlaygroundScreen> {
+            PlaygroundScreen(
+                onNavigateTo = { route -> navController.navigate(route) }
+            )
+        }
+
+        composable<PlaygroundRoutes.CreditCardForm> {
+            CreditCardFormPreview(
+                onNavigateBack = { navController.navigateUp() }
+            )
         }
         composable<HomeRoutes.ConversationsScreen> {
             ConversationsScreen(

--- a/app/src/main/java/com/example/nexum_cliente/ui/navigation/rutes/DrawerRoutes.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/navigation/rutes/DrawerRoutes.kt
@@ -17,4 +17,7 @@ sealed class DrawerRoutes {
 
     @Serializable
     object SettingsScreen : DrawerRoutes()
+
+    @Serializable
+    object PlaygroundScreen : DrawerRoutes()
 }

--- a/app/src/main/java/com/example/nexum_cliente/ui/navigation/rutes/PlaygroundRoutes.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/navigation/rutes/PlaygroundRoutes.kt
@@ -1,0 +1,9 @@
+package com.example.nexum_cliente.ui.navigation.rutes
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class PlaygroundRoutes {
+    @Serializable
+    object CreditCardForm : PlaygroundRoutes()
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/home/DrawerNavigation.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/home/DrawerNavigation.kt
@@ -2,8 +2,10 @@ package com.example.nexum_cliente.ui.presenter.home
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AccountCircle
+import androidx.compose.material.icons.outlined.Science
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.example.nexum_cliente.ui.navigation.rutes.DrawerRoutes
@@ -38,5 +40,13 @@ enum class DrawerNavigation(
         icon = Icons.Outlined.Settings,
         selectedIcon = Icons.Filled.Settings,
         unselectedIcon = Icons.Outlined.Settings,
+    ),
+    PLAYGROUND(
+        title = "Playground",
+        description = "Componentes UI",
+        route = DrawerRoutes.PlaygroundScreen,
+        icon = Icons.Outlined.Science,
+        selectedIcon = Icons.Filled.Science,
+        unselectedIcon = Icons.Outlined.Science,
     ),
 }

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/payment/PaymentScreen.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/payment/PaymentScreen.kt
@@ -1,0 +1,98 @@
+package com.example.nexum_cliente.ui.presenter.payment
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.nexum_cliente.ui.components.creditcard.CreditCardForm
+import com.example.nexum_cliente.ui.components.creditcard.CreditCardState
+import kotlinx.coroutines.launch
+
+/**
+ * Example screen demonstrating how to embed [CreditCardForm] inside a
+ * real Compose screen with a [Scaffold], back navigation, and a Snackbar
+ * confirmation.
+ *
+ * This is an integration example. In production, replace [rememberSaveable]
+ * state with a ViewModel that handles payment submission.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PaymentScreen(
+    onNavigateBack: () -> Unit = {}
+) {
+    var cardState by rememberSaveable { mutableStateOf(CreditCardState()) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    val titlePayment = "Payment"
+    val titleCardDetails = "Card details"
+    val messageSuccess = "Payment submitted successfully"
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(titlePayment) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Navigate back"
+                        )
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Text(
+                text = titleCardDetails,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            CreditCardForm(
+                state = cardState,
+                onStateChange = { cardState = it },
+                onSubmit = { submittedState ->
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar(messageSuccess)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/CreditCardFormPreview.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/CreditCardFormPreview.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
+
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -37,7 +37,7 @@ import kotlinx.coroutines.launch
 fun CreditCardFormPreview(
     onNavigateBack: () -> Unit
 ) {
-    var state by rememberSaveable { mutableStateOf(CreditCardState()) }
+    var state by remember { mutableStateOf(CreditCardState()) }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/CreditCardFormPreview.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/CreditCardFormPreview.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.nexum_cliente.ui.components.creditcard.CreditCardForm
 import com.example.nexum_cliente.ui.components.creditcard.CreditCardState
+import com.example.nexum_cliente.ui.components.creditcard.CreditCardVisual
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -81,6 +82,15 @@ fun CreditCardFormPreview(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
+
+            HorizontalDivider()
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Live card preview
+            CreditCardVisual(state = state)
+
+            Spacer(modifier = Modifier.height(8.dp))
 
             HorizontalDivider()
 

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/CreditCardFormPreview.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/CreditCardFormPreview.kt
@@ -1,0 +1,103 @@
+package com.example.nexum_cliente.ui.presenter.playground
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.nexum_cliente.ui.components.creditcard.CreditCardForm
+import com.example.nexum_cliente.ui.components.creditcard.CreditCardState
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreditCardFormPreview(
+    onNavigateBack: () -> Unit
+) {
+    var state by rememberSaveable { mutableStateOf(CreditCardState()) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val titleScreen = "Credit Card Form"
+    val labelDescription = "Componente: CreditCardForm"
+    val labelPackage = "ui.components.creditcard"
+    val messageSubmit = "onSubmit disparado — estado: %s"
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(titleScreen) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Volver"
+                        )
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            // Component metadata header
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                Text(
+                    text = labelDescription,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Text(
+                    text = labelPackage,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            HorizontalDivider()
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // The component under test
+            CreditCardForm(
+                state = state,
+                onStateChange = { state = it },
+                onSubmit = { submittedState ->
+                    scope.launch {
+                        snackbarHostState.showSnackbar(
+                            messageSubmit.format(submittedState.cardType.name)
+                        )
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/PlaygroundScreen.kt
+++ b/app/src/main/java/com/example/nexum_cliente/ui/presenter/playground/PlaygroundScreen.kt
@@ -1,0 +1,135 @@
+package com.example.nexum_cliente.ui.presenter.playground
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForwardIos
+import androidx.compose.material.icons.filled.CreditCard
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.example.nexum_cliente.ui.navigation.rutes.PlaygroundRoutes
+
+// ---------------------------------------------------------------------------
+// Data model for a playground entry
+// ---------------------------------------------------------------------------
+
+data class PlaygroundComponent(
+    val title: String,
+    val description: String,
+    val icon: ImageVector,
+    val route: PlaygroundRoutes
+)
+
+private val playgroundComponents = listOf(
+    PlaygroundComponent(
+        title = "Credit Card Form",
+        description = "Formulario de tarjeta de crédito con validación y detección de red",
+        icon = Icons.Filled.CreditCard,
+        route = PlaygroundRoutes.CreditCardForm
+    )
+)
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlaygroundScreen(
+    onNavigateTo: (PlaygroundRoutes) -> Unit
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Playground") }
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(playgroundComponents) { component ->
+                PlaygroundComponentCard(
+                    component = component,
+                    onClick = { onNavigateTo(component.route) }
+                )
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Component card
+// ---------------------------------------------------------------------------
+
+@Composable
+private fun PlaygroundComponentCard(
+    component: PlaygroundComponent,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = component.icon,
+                contentDescription = null,
+                modifier = Modifier.size(32.dp),
+                tint = MaterialTheme.colorScheme.primary
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = component.title,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = component.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardFormTest.kt
+++ b/app/src/test/java/com/example/nexum_cliente/ui/components/creditcard/CreditCardFormTest.kt
@@ -1,0 +1,204 @@
+package com.example.nexum_cliente.ui.components.creditcard
+
+import androidx.compose.ui.text.AnnotatedString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CreditCardFormTest {
+
+    // ── detectCardType ───────────────────────────────────────────────────────
+
+    @Test
+    fun `detectCardType returns VISA for number starting with 4`() {
+        assertEquals(CardType.VISA, detectCardType("4111111111111111"))
+    }
+
+    @Test
+    fun `detectCardType returns MASTERCARD for prefix in range 51-55`() {
+        assertEquals(CardType.MASTERCARD, detectCardType("5100000000000000"))
+        assertEquals(CardType.MASTERCARD, detectCardType("5500000000000000"))
+        assertEquals(CardType.MASTERCARD, detectCardType("5300000000000000"))
+    }
+
+    @Test
+    fun `detectCardType returns AMEX for prefix 34 or 37`() {
+        assertEquals(CardType.AMEX, detectCardType("341111111111111"))
+        assertEquals(CardType.AMEX, detectCardType("371111111111111"))
+    }
+
+    @Test
+    fun `detectCardType returns UNKNOWN for unrecognised prefix`() {
+        assertEquals(CardType.UNKNOWN, detectCardType("6011111111111117"))
+        assertEquals(CardType.UNKNOWN, detectCardType("3000000000000004"))
+    }
+
+    @Test
+    fun `detectCardType returns UNKNOWN for empty string`() {
+        assertEquals(CardType.UNKNOWN, detectCardType(""))
+    }
+
+    @Test
+    fun `detectCardType handles partial input safely`() {
+        assertEquals(CardType.VISA, detectCardType("4"))
+        assertEquals(CardType.UNKNOWN, detectCardType("5"))
+        assertEquals(CardType.AMEX, detectCardType("37"))
+    }
+
+    // ── CardNumberVisualTransformation ───────────────────────────────────────
+
+    @Test
+    fun `CardNumberVisualTransformation formats 16 digits with spaces`() {
+        val transformation = CardNumberVisualTransformation()
+        val result = transformation.filter(AnnotatedString("1234567890123456"))
+        assertEquals("1234 5678 9012 3456", result.text.text)
+    }
+
+    @Test
+    fun `CardNumberVisualTransformation handles 4 digits without trailing space`() {
+        val transformation = CardNumberVisualTransformation()
+        val result = transformation.filter(AnnotatedString("1234"))
+        assertEquals("1234", result.text.text)
+    }
+
+    @Test
+    fun `CardNumberVisualTransformation handles 5 digits`() {
+        val transformation = CardNumberVisualTransformation()
+        val result = transformation.filter(AnnotatedString("12345"))
+        assertEquals("1234 5", result.text.text)
+    }
+
+    @Test
+    fun `CardNumberVisualTransformation offset mapping originalToTransformed is correct`() {
+        val transformation = CardNumberVisualTransformation()
+        val result = transformation.filter(AnnotatedString("1234567890123456"))
+        // Offset 0..4: no spaces yet → same
+        assertEquals(0, result.offsetMapping.originalToTransformed(0))
+        assertEquals(4, result.offsetMapping.originalToTransformed(4))
+        // After 4 digits one space is added
+        assertEquals(6, result.offsetMapping.originalToTransformed(5))
+        // After 8 raw digits one more space has been inserted (at formatted pos 4)
+        // "1234 5678" = 9 chars → cursor at 9
+        assertEquals(9, result.offsetMapping.originalToTransformed(8))
+    }
+
+    // ── ExpirationDateVisualTransformation ───────────────────────────────────
+
+    @Test
+    fun `ExpirationDateVisualTransformation formats 4 digits as MM slash YY`() {
+        val transformation = ExpirationDateVisualTransformation()
+        val result = transformation.filter(AnnotatedString("1229"))
+        assertEquals("12/29", result.text.text)
+    }
+
+    @Test
+    fun `ExpirationDateVisualTransformation does not add slash for 2 digits`() {
+        val transformation = ExpirationDateVisualTransformation()
+        val result = transformation.filter(AnnotatedString("12"))
+        assertEquals("12", result.text.text)
+    }
+
+    @Test
+    fun `ExpirationDateVisualTransformation handles 3 digits`() {
+        val transformation = ExpirationDateVisualTransformation()
+        val result = transformation.filter(AnnotatedString("122"))
+        assertEquals("12/2", result.text.text)
+    }
+
+    @Test
+    fun `ExpirationDateVisualTransformation offset mapping is correct`() {
+        val transformation = ExpirationDateVisualTransformation()
+        val result = transformation.filter(AnnotatedString("1229"))
+        // Offsets 0–2 unchanged
+        assertEquals(0, result.offsetMapping.originalToTransformed(0))
+        assertEquals(2, result.offsetMapping.originalToTransformed(2))
+        // After index 2 the slash adds 1
+        assertEquals(4, result.offsetMapping.originalToTransformed(3))
+        assertEquals(5, result.offsetMapping.originalToTransformed(4))
+    }
+
+    // ── Submit button enabled/disabled logic ──────────────────────────────────
+
+    @Test
+    fun `form is invalid when all fields are empty`() {
+        val state = CreditCardState()
+        assertFalse(isFormValidForTest(state))
+    }
+
+    @Test
+    fun `form is invalid when card number has fewer than 16 digits`() {
+        val state = CreditCardState(
+            cardNumber = "123456789012345", // 15 digits
+            cardHolderName = "John Doe",
+            expirationDate = "1229",
+            cvv = "123"
+        )
+        assertFalse(isFormValidForTest(state))
+    }
+
+    @Test
+    fun `form is invalid when cardholder name is blank`() {
+        val state = CreditCardState(
+            cardNumber = "1234567890123456",
+            cardHolderName = "   ",
+            expirationDate = "1229",
+            cvv = "123"
+        )
+        assertFalse(isFormValidForTest(state))
+    }
+
+    @Test
+    fun `form is invalid when expiry has fewer than 4 digits`() {
+        val state = CreditCardState(
+            cardNumber = "1234567890123456",
+            cardHolderName = "John Doe",
+            expirationDate = "122",
+            cvv = "123"
+        )
+        assertFalse(isFormValidForTest(state))
+    }
+
+    @Test
+    fun `form is invalid when cvv has fewer than 3 digits`() {
+        val state = CreditCardState(
+            cardNumber = "1234567890123456",
+            cardHolderName = "John Doe",
+            expirationDate = "1229",
+            cvv = "12"
+        )
+        assertFalse(isFormValidForTest(state))
+    }
+
+    @Test
+    fun `form is valid when all fields are correctly filled`() {
+        val state = CreditCardState(
+            cardNumber = "1234567890123456",
+            cardHolderName = "John Doe",
+            expirationDate = "1229",
+            cvv = "123"
+        )
+        assertTrue(isFormValidForTest(state))
+    }
+
+    @Test
+    fun `form is valid with a 4-digit CVV for Amex`() {
+        val state = CreditCardState(
+            cardNumber = "3714496353984301",
+            cardHolderName = "Jane Smith",
+            expirationDate = "0628",
+            cvv = "1234"
+        )
+        assertTrue(isFormValidForTest(state))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test-accessible validation mirror (duplicates private logic from CreditCardForm)
+// ---------------------------------------------------------------------------
+
+private fun isFormValidForTest(state: CreditCardState): Boolean =
+    state.cardNumber.length == 16 &&
+        state.cardHolderName.isNotBlank() &&
+        state.expirationDate.length == 4 &&
+        state.cvv.length in 3..4


### PR DESCRIPTION
- Se añadio un componente de formulario interactivo para tarjetas de credito:
<img width="50%" alt="Grabación-de-pantalla-desde-2026-06-11-18-50-06" src="https://github.com/user-attachments/assets/e179d57c-8dd5-4735-8e3c-cff91465cc3e" />

- Se añadio una seccion 'playground' para testear y probar componentes aislados rapidamente.
<img width="50%"  alt="ezgif-31f7704f8edb1c8f" src="https://github.com/user-attachments/assets/9f3af50c-dfa9-4034-8e70-16e24a3e0684" />
